### PR TITLE
Filtering artifact search for package.json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.jenkins-ci.tools</groupId>
             <artifactId>maven-hpi-plugin</artifactId>
-            <version>1.122</version>
+            <version>3.17</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -107,10 +107,12 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <testSource>1.8</testSource>
+                    <testTarget>1.8</testTarget>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/io/jenkins/blueocean/maven/plugin/ProcessUpstreamDependenciesMojo.java
+++ b/src/main/java/io/jenkins/blueocean/maven/plugin/ProcessUpstreamDependenciesMojo.java
@@ -13,6 +13,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import javax.annotation.Nonnull;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -179,7 +180,7 @@ public class ProcessUpstreamDependenciesMojo extends AbstractJenkinsMojo {
         try {
             if (!isLocalProject) { // not the local project
                 //filtering system they cannot contains package.json files
-                if(! artifact.getScope().equals("system")) {
+                if(! artifact.getScope().equals(Artifact.SCOPE_SYSTEM)) {
                     if (getLog().isDebugEnabled()) getLog().debug("Testing artifact for Blue Ocean plugins: " + artifact.toString());
                     List<Contents> jarEntries = findJarEntries(artifact.getFile().toURI(), "package.json");
                     if (jarEntries.size() > 0) {

--- a/src/main/java/io/jenkins/blueocean/maven/plugin/ProcessUpstreamDependenciesMojo.java
+++ b/src/main/java/io/jenkins/blueocean/maven/plugin/ProcessUpstreamDependenciesMojo.java
@@ -178,11 +178,14 @@ public class ProcessUpstreamDependenciesMojo extends AbstractJenkinsMojo {
         boolean isLocalProject = node.getArtifact().equals(project.getArtifact());
         try {
             if (!isLocalProject) { // not the local project
-                if (getLog().isDebugEnabled()) getLog().debug("Testing artifact for Blue Ocean plugins: " + artifact.toString());
-                List<Contents> jarEntries = findJarEntries(artifact.getFile().toURI(), "package.json");
-                if (jarEntries.size() > 0) {
-                    getLog().info("Adding upstream Blue Ocean plugin: " + artifact.toString());
-                    results.add(artifact);
+                //filtering system they cannot contains package.json files
+                if(! artifact.getScope().equals("system")) {
+                    if (getLog().isDebugEnabled()) getLog().debug("Testing artifact for Blue Ocean plugins: " + artifact.toString());
+                    List<Contents> jarEntries = findJarEntries(artifact.getFile().toURI(), "package.json");
+                    if (jarEntries.size() > 0) {
+                        getLog().info("Adding upstream Blue Ocean plugin: " + artifact.toString());
+                        results.add(artifact);
+                    }
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
system artifact are causing issue in the search of package.json, can be ignored.

Issue detected when trying to bump blueocean jenkins.version to 2.277.3, because of transitive dependency com.sun:tools:jar:1.8.0:system

```
[INFO] +- org.jenkins-ci.main:jenkins-core:jar:2.277.3:provided
[INFO] |  +- org.apache.ant:ant:jar:1.10.9:provided
[INFO] |  |  +- org.apache.ant:ant-launcher:jar:1.10.9:provided
[INFO] |  |  \- com.sun:tools:jar:1.8.0:system
```

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
